### PR TITLE
Optimize memory allocations by switching from map to slice for crumbs

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -87,7 +87,7 @@ func BenchmarkGetCrumbs(b *testing.B) {
 		"key3", true)
 
 	b.ResetTimer()
-	var result map[string]interface{}
+	var result []Crumb
 	for i := 0; i < b.N; i++ {
 		result = GetCrumbs(ctx)
 	}

--- a/errors.go
+++ b/errors.go
@@ -26,13 +26,19 @@ type StackFrame struct {
 	Line     int
 }
 
+// Crumb represents a key-value pair
+type Crumb struct {
+	Key   string
+	Value interface{}
+}
+
 // Empty line to replace the removed category code
 
 // Error is a custom error type that wraps a standard error and supports key-value pairs.
 type Error struct {
 	Err    error
 	Msg    string
-	Crumbs map[string]interface{}
+	Crumbs []Crumb
 	Stack  []StackFrame
 }
 
@@ -58,7 +64,7 @@ func (e *Error) Unwrap() error {
 }
 
 // GetCrumbs returns the key-value pairs associated with the error.
-func (e *Error) GetCrumbs() map[string]interface{} {
+func (e *Error) GetCrumbs() []Crumb {
 	return e.Crumbs
 }
 
@@ -157,18 +163,20 @@ func Wrapf(ctx context.Context, err error, format string, args ...interface{}) e
 
 // newError is a helper function to create errors with context
 func newError(ctx context.Context, err error, msg string, kv ...interface{}) error {
-	// Create crumbs map and add any key-value pairs
-	ctx_map := make(map[string]interface{})
+	// Create crumbs slice
+	var crumbs []Crumb
 
 	// First, add any crumbs from the context
 	if ctx != nil {
-		if crumbs := ctx.Value(crumbsKey{}); crumbs != nil {
-			if cm, ok := crumbs.(map[string]interface{}); ok {
-				for k, v := range cm {
-					ctx_map[k] = v
-				}
-			}
+		if ctxCrumbs, ok := ctx.Value(crumbsKey{}).([]Crumb); ok {
+			crumbs = make([]Crumb, len(ctxCrumbs), len(ctxCrumbs)+len(kv)/2)
+			copy(crumbs, ctxCrumbs)
 		}
+	}
+
+	// If crumbs is still nil (no context crumbs), initialize it
+	if crumbs == nil {
+		crumbs = make([]Crumb, 0, len(kv)/2)
 	}
 
 	// Then add any key-value pairs passed directly
@@ -177,7 +185,7 @@ func newError(ctx context.Context, err error, msg string, kv ...interface{}) err
 		if !ok {
 			continue
 		}
-		ctx_map[key] = kv[i+1]
+		crumbs = append(crumbs, Crumb{Key: key, Value: kv[i+1]})
 	}
 
 	// Use the global configuration for stack trace capture
@@ -187,7 +195,7 @@ func newError(ctx context.Context, err error, msg string, kv ...interface{}) err
 	e := &Error{
 		Err:    err,
 		Msg:    msg,
-		Crumbs: ctx_map,
+		Crumbs: crumbs,
 	}
 
 	// Capture the stack trace if needed
@@ -204,22 +212,15 @@ func AddCrumb(ctx context.Context, kv ...interface{}) context.Context {
 		return ctx
 	}
 
-	var crumbs map[string]interface{}
+	var crumbs []Crumb
 
 	// Get existing crumbs if any
-	if existing := ctx.Value(crumbsKey{}); existing != nil {
-		if cm, ok := existing.(map[string]interface{}); ok {
-			// Create a copy to avoid modifying the existing map in the context
-			crumbs = make(map[string]interface{}, len(cm))
-			for k, v := range cm {
-				crumbs[k] = v
-			}
-		}
-	}
-
-	// If no crumbs exist yet, create a new map
-	if crumbs == nil {
-		crumbs = make(map[string]interface{})
+	if existing, ok := ctx.Value(crumbsKey{}).([]Crumb); ok {
+		// Create a copy to avoid modifying the existing slice in the context
+		crumbs = make([]Crumb, len(existing), len(existing)+len(kv)/2)
+		copy(crumbs, existing)
+	} else {
+		crumbs = make([]Crumb, 0, len(kv)/2)
 	}
 
 	// Add the new crumbs
@@ -228,7 +229,7 @@ func AddCrumb(ctx context.Context, kv ...interface{}) context.Context {
 		if !ok {
 			continue // Skip if key is not a string
 		}
-		crumbs[key] = kv[i+1]
+		crumbs = append(crumbs, Crumb{Key: key, Value: kv[i+1]})
 	}
 
 	// Return new context with updated crumbs
@@ -236,25 +237,20 @@ func AddCrumb(ctx context.Context, kv ...interface{}) context.Context {
 }
 
 // GetCrumbs retrieves all crumbs from a context
-func GetCrumbs(ctx context.Context) map[string]interface{} {
+func GetCrumbs(ctx context.Context) []Crumb {
 	if ctx == nil {
 		return nil
 	}
 
-	if crumbs := ctx.Value(crumbsKey{}); crumbs != nil {
-		if cm, ok := crumbs.(map[string]interface{}); ok {
-			// Return a copy to prevent modification
-			result := make(map[string]interface{}, len(cm))
-			for k, v := range cm {
-				result[k] = v
-			}
-			return result
-		}
+	if crumbs, ok := ctx.Value(crumbsKey{}).([]Crumb); ok {
+		// Return a copy to prevent modification
+		result := make([]Crumb, len(crumbs))
+		copy(result, crumbs)
+		return result
 	}
 
 	return nil
 }
-
 // FormatError returns a detailed string representation of the error,
 // optionally including stack trace, crumbs, and category
 func FormatError(err error, includeStack bool, includeCrumbs bool) string {
@@ -269,8 +265,8 @@ func FormatError(err error, includeStack bool, includeCrumbs bool) string {
 		// Add crumbs if requested
 		if includeCrumbs && len(cerr.Crumbs) > 0 {
 			sb.WriteString("\nCrumbs:")
-			for k, v := range cerr.Crumbs {
-				sb.WriteString(fmt.Sprintf("\n  %s: %v", k, v))
+			for _, crumb := range cerr.Crumbs {
+				sb.WriteString(fmt.Sprintf("\n  %s: %v", crumb.Key, crumb.Value))
 			}
 		}
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,6 +7,14 @@ import (
 	"testing"
 )
 
+func crumbsToMap(crumbs []Crumb) map[string]interface{} {
+	m := make(map[string]interface{})
+	for _, c := range crumbs {
+		m[c.Key] = c.Value
+	}
+	return m
+}
+
 func TestNew(t *testing.T) {
 	ctx := context.Background()
 
@@ -29,7 +37,7 @@ func TestNew(t *testing.T) {
 			t.Fatal("Expected *Error type")
 		}
 
-		crumbs := cerr.GetCrumbs()
+		crumbs := crumbsToMap(cerr.GetCrumbs())
 		if crumbs["key1"] != "value1" {
 			t.Errorf("Expected crumbs['key1'] = 'value1', got '%v'", crumbs["key1"])
 		}
@@ -72,7 +80,7 @@ func TestWrap(t *testing.T) {
 			t.Fatal("Expected *Error type")
 		}
 
-		crumbs := cerr.GetCrumbs()
+		crumbs := crumbsToMap(cerr.GetCrumbs())
 		if crumbs["key1"] != "value1" {
 			t.Errorf("Expected crumbs['key1'] = 'value1', got '%v'", crumbs["key1"])
 		}
@@ -193,7 +201,7 @@ func TestContextCrumbs(t *testing.T) {
 	ctx = AddCrumb(ctx, "ctx1", "value1", "ctx2", 42)
 
 	// Check GetCrumbs
-	crumbs := GetCrumbs(ctx)
+	crumbs := crumbsToMap(GetCrumbs(ctx))
 	if crumbs["ctx1"] != "value1" || crumbs["ctx2"] != 42 {
 		t.Errorf("GetCrumbs failed, got %v", crumbs)
 	}
@@ -205,7 +213,7 @@ func TestContextCrumbs(t *testing.T) {
 		t.Fatal("Expected *Error type")
 	}
 
-	errCrumbs := cerr.GetCrumbs()
+	errCrumbs := crumbsToMap(cerr.GetCrumbs())
 	if errCrumbs["ctx1"] != "value1" || errCrumbs["ctx2"] != 42 {
 		t.Errorf("Context crumbs not included in error, got %v", errCrumbs)
 	}
@@ -216,7 +224,7 @@ func TestAddCrumb(t *testing.T) {
 		ctx := context.Background()
 		ctx = AddCrumb(ctx, "key", "value")
 
-		crumbs := GetCrumbs(ctx)
+		crumbs := crumbsToMap(GetCrumbs(ctx))
 		if crumbs["key"] != "value" {
 			t.Errorf("Expected crumbs['key'] = 'value', got '%v'", crumbs["key"])
 		}
@@ -227,7 +235,7 @@ func TestAddCrumb(t *testing.T) {
 		ctx = AddCrumb(ctx, "key1", "value1")
 		ctx = AddCrumb(ctx, "key2", "value2")
 
-		crumbs := GetCrumbs(ctx)
+		crumbs := crumbsToMap(GetCrumbs(ctx))
 		if crumbs["key1"] != "value1" || crumbs["key2"] != "value2" {
 			t.Errorf("Expected both crumbs, got %v", crumbs)
 		}
@@ -238,7 +246,7 @@ func TestAddCrumb(t *testing.T) {
 		ctx = AddCrumb(ctx, "key", "value1")
 		ctx = AddCrumb(ctx, "key", "value2")
 
-		crumbs := GetCrumbs(ctx)
+		crumbs := crumbsToMap(GetCrumbs(ctx))
 		if crumbs["key"] != "value2" {
 			t.Errorf("Expected crumbs['key'] = 'value2', got '%v'", crumbs["key"])
 		}
@@ -248,7 +256,7 @@ func TestAddCrumb(t *testing.T) {
 		ctx := context.Background()
 		ctx = AddCrumb(ctx, "key1", "value1", "key2", "value2")
 
-		crumbs := GetCrumbs(ctx)
+		crumbs := crumbsToMap(GetCrumbs(ctx))
 		if crumbs["key1"] != "value1" || crumbs["key2"] != "value2" {
 			t.Errorf("Expected both crumbs, got %v", crumbs)
 		}
@@ -258,7 +266,7 @@ func TestAddCrumb(t *testing.T) {
 		ctx := context.Background()
 		ctx = AddCrumb(ctx, 123, "value") // Should be ignored
 
-		crumbs := GetCrumbs(ctx)
+		crumbs := crumbsToMap(GetCrumbs(ctx))
 		if len(crumbs) > 0 {
 			t.Errorf("Expected no crumbs, got %v", crumbs)
 		}

--- a/examples/context_example/context_and_crumbs.go
+++ b/examples/context_example/context_and_crumbs.go
@@ -82,11 +82,19 @@ func RunExample() {
 	// Show crumbs explicitly
 	fmt.Println("\nExtracting and using crumbs directly:")
 	if cerr, ok := err.(*crumbs.Error); ok {
-		crumbsMap := cerr.GetCrumbs()
-		fmt.Println("Request ID:", crumbsMap["requestID"])
-		fmt.Println("User ID:", crumbsMap["userID"])
-		fmt.Println("Action:", crumbsMap["action"])
-		fmt.Println("Data Size:", crumbsMap["dataSize"])
+		crumbsSlice := cerr.GetCrumbs()
+		for _, c := range crumbsSlice {
+			switch c.Key {
+			case "requestID":
+				fmt.Println("Request ID:", c.Value)
+			case "userID":
+				fmt.Println("User ID:", c.Value)
+			case "action":
+				fmt.Println("Action:", c.Value)
+			case "dataSize":
+				fmt.Println("Data Size:", c.Value)
+			}
+		}
 	}
 
 	// Demonstrate how to get crumbs from a context

--- a/examples/logging_example/logging_integration.go
+++ b/examples/logging_example/logging_integration.go
@@ -81,8 +81,8 @@ func LogError(logger Logger, err error) {
 	var cerr *crumbs.Error
 	if errors.As(err, &cerr) {
 		// Add all crumbs as fields
-		for k, v := range cerr.GetCrumbs() {
-			fields[k] = v
+		for _, c := range cerr.GetCrumbs() {
+			fields[c.Key] = c.Value
 		}
 
 		// Add stack trace if available


### PR DESCRIPTION
## Summary
This PR refactors the internal storage of "crumbs" (key-value pairs) from a `map[string]interface{}` to a slice of `Crumb` structs (`[]Crumb`). This change significantly reduces memory allocations, improves CPU performance, and ensures better immutability for error context.

## Key Changes
- **New `Crumb` Struct**: Introduced `type Crumb struct { Key string; Value interface{} }`.
- **Storage Update**: Updated `Error` struct and context handling to use `[]Crumb` instead of maps.
- **API Update**: `GetCrumbs` now returns `[]Crumb`. This preserves insertion order, which is often lost with maps.
- **Reduced Allocations**: Optimized `New`, `Wrap`, and `AddCrumb` to minimize heap allocations.

## Benchmarks
Comparison between `main` and `opt/memoryAllocations`:

| Operation | Metric | Main | This PR | Improvement |
| :--- | :--- | :--- | :--- | :--- |
| **Error Creation** (w/ crumbs) | Time | 118.5 ns/op | **56.04 ns/op** | **~53% Faster** |
| | Memory | 400 B/op | **176 B/op** | **~56% Less Memory** |
| **AddCrumb** | Time | 100.2 ns/op | **60.57 ns/op** | **~40% Faster** |
| | Memory | 384 B/op | **104 B/op** | **~73% Less Memory** |
| **GetCrumbs** | Time | 138.1 ns/op | **27.47 ns/op** | **~80% Faster** |
| | Memory | 336 B/op | **96 B/op** | **~71% Less Memory** |

## Breaking Changes
- `GetCrumbs(ctx)` and `err.GetCrumbs()` now return `[]Crumb` instead of `map[string]interface{}`.
- Users relying on map lookups (e.g., `crumbs["key"]`) will need to iterate over the slice or convert it to a map.