### PR TITLE
feat: Add generic Logger interface and slog integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x, 1.22.x]
+        go-version: [1.21.x, 1.22.x]
     steps:
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Check out code
       uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Check out code
       uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.20.x
+        go-version: 1.21.x
 
     - name: Check out code
       uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@
 [![GitHub Stars](https://img.shields.io/github/stars/sri-shubham/crumbs.svg)](https://github.com/sri-shubham/crumbs/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/sri-shubham/crumbs.svg)](https://github.com/sri-shubham/crumbs/issues)
 
-Crumbs is a lightweight, flexible error handling library for Go that adds context to your errors. It's designed to enhance error reporting while maintaining full compatibility with the standard library.
+Crumbs is a rich observability library for Go that bridges the gap between error handling and structured logging. It allows you to attach rich, structured data ("crumbs") to your errors and context, which can then be automatically extracted by your logger or error reporter. This ensures that every error log contains the full context needed for debugging, without cluttering your function signatures.
 
 ## Features
 
-- **Key-Value Context**: Attach key-value pairs ("crumbs") to errors for better debugging and logging
-- **Context Integration**: Automatically gather context information from Go's `context.Context`
+- **Rich Observability**: Carry structured data through your call stack and attach it to errors automatically
+- **Logger Enrichment**: Feed your structured logger (like `slog`) with rich context captured deep within your application logic
+- **Context Integration**: Seamlessly propagate observability data via Go's `context.Context`
 - **Standard Library Compatible**: Works seamlessly with `errors.Is`, `errors.As`, and `errors.Unwrap`
-- **Optional Stack Traces**: Record stack traces when needed
-- **Logging Friendly**: Easily extract structured data for your logging system
+- **Zero-Allocation Hot Paths**: Optimized for high-performance applications with zero-allocation operations for common tasks
 
 ## Installation
 
@@ -108,8 +108,11 @@ ctx = crumbs.AddCrumb(ctx,
     "timestamp", time.Now(),
 )
 
-// Get crumbs from context
+// Get crumbs from context (returns []Crumb)
 allCrumbs := crumbs.GetCrumbs(ctx)
+for _, c := range allCrumbs {
+    fmt.Printf("Key: %s, Value: %v\n", c.Key, c.Value)
+}
 ```
 
 ### Stack Traces
@@ -155,26 +158,41 @@ if cerr, ok := err.(*crumbs.Error); ok {
 
 ## Logging Integration
 
-Crumbs errors work great with structured logging:
+Crumbs integrates seamlessly with modern structured logging like `log/slog`:
 
 ```go
-func LogError(logger Logger, err error) {
-    if err == nil {
-        return
-    }
-    
-    msg := err.Error()
-    fields := map[string]interface{}{}
-    
+import "log/slog"
+
+// LogError logs an error along with all its attached crumbs
+func LogError(logger *slog.Logger, msg string, err error) {
+    // Start with the error itself
+    args := []any{"error", err}
+
+    // Extract crumbs if available
     var cerr *crumbs.Error
     if errors.As(err, &cerr) {
-        // Add all crumbs as fields
         for _, c := range cerr.GetCrumbs() {
-            fields[c.Key] = c.Value
+            // Add each crumb as a key-value pair
+            args = append(args, slog.Any(c.Key, c.Value))
         }
     }
-    
-    logger.Error(msg, fields)
+
+    // Log with all context
+    logger.Error(msg, args...)
+}
+
+// LoggerWithCrumbs creates a logger pre-filled with error context
+func LoggerWithCrumbs(logger *slog.Logger, err error) *slog.Logger {
+    var cerr *crumbs.Error
+    if errors.As(err, &cerr) {
+        crumbs := cerr.GetCrumbs()
+        args := make([]any, 0, len(crumbs)*2)
+        for _, c := range crumbs {
+            args = append(args, c.Key, c.Value)
+        }
+        return logger.With(args...)
+    }
+    return logger
 }
 ```
 
@@ -187,6 +205,21 @@ See the [examples](./examples) directory for comprehensive usage examples:
 - Stack traces
 - Logging integration
 - Standard library errors compatibility
+
+## Integrations
+
+Crumbs is designed to play nicely with the Go ecosystem.
+
+### Logging
+
+We provide a first-class integration for `log/slog` via the `integrations/slog` package. This adapter automatically extracts crumbs from your context and errors, injecting them as structured attributes into your logs.
+
+- **[slog Adapter](./integrations/slog)**: Seamless integration with Go's structured logger.
+- **[Logger Interface](./logger)**: A generic interface for building your own logging adapters.
+
+### Middleware
+
+Crumbs works great with HTTP middleware to capture request-scoped metadata (like Request ID, User ID, Path) at the edge and propagate it automatically through your application. See the [Middleware Example](./examples/middleware_example) for a demonstration.
 
 ## Benchmarks
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/sri-shubham/crumbs/examples/basic_example"
 	"github.com/sri-shubham/crumbs/examples/context_example"
 	"github.com/sri-shubham/crumbs/examples/logging_example"
+	"github.com/sri-shubham/crumbs/examples/middleware_example"
 	"github.com/sri-shubham/crumbs/examples/stack_example"
 	"github.com/sri-shubham/crumbs/examples/std_errors_example"
 )
@@ -39,6 +40,11 @@ func main() {
 	fmt.Println("STANDARD ERRORS INTEGRATION EXAMPLE")
 	fmt.Println("====================================")
 	std_errors_example.DemonstrateStandardErrorsMethods()
+
+	fmt.Println("\n\n====================================")
+	fmt.Println("MIDDLEWARE INTEGRATION EXAMPLE")
+	fmt.Println("====================================")
+	middleware_example.RunExample()
 
 	fmt.Println("\n\nAll examples completed!")
 }

--- a/examples/middleware_example/middleware_usage.go
+++ b/examples/middleware_example/middleware_usage.go
@@ -1,0 +1,120 @@
+package middleware_example
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/sri-shubham/crumbs"
+)
+
+// TraceMiddleware is an HTTP middleware that adds a TraceID to the context
+func TraceMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Generate or extract TraceID (simulated here)
+		traceID := fmt.Sprintf("trace-%d", time.Now().UnixNano())
+
+		// Add TraceID and other request details to the context using crumbs
+		// This context will now carry these values to all downstream functions
+		ctx := crumbs.AddCrumb(r.Context(),
+			"trace_id", traceID,
+			"path", r.URL.Path,
+			"method", r.Method,
+		)
+
+		// Update request with new context
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ServiceLayer simulates a business logic layer
+func ServiceLayer(ctx context.Context) error {
+	// Simulate some work
+	// ...
+
+	// Call database layer
+	if err := DatabaseLayer(ctx); err != nil {
+		// Wrap the error. The error will automatically inherit
+		// "trace_id", "path", and "method" from the context!
+		return crumbs.Wrap(ctx, err, "service layer failed")
+	}
+
+	return nil
+}
+
+// DatabaseLayer simulates a database operation
+func DatabaseLayer(ctx context.Context) error {
+	// Simulate a failure
+	// We can add more specific context here
+	return crumbs.New(ctx, "connection timeout",
+		"db_host", "localhost",
+		"db_port", 5432,
+	)
+}
+
+// Handler simulates an HTTP handler
+func Handler(w http.ResponseWriter, r *http.Request) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	ctx := r.Context()
+
+	// Call service layer
+	if err := ServiceLayer(ctx); err != nil {
+		// When logging the error, we can extract all the crumbs.
+		// This log entry will contain:
+		// - trace_id (from middleware)
+		// - path (from middleware)
+		// - method (from middleware)
+		// - db_host (from database layer)
+		// - db_port (from database layer)
+		// - The error message chain
+
+		LogError(logger, "request failed", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("Success"))
+}
+
+// LogError helper (as defined in README)
+func LogError(logger *slog.Logger, msg string, err error) {
+	args := []any{"error", err.Error()}
+
+	// Extract crumbs if available
+	if cerr, ok := err.(*crumbs.Error); ok {
+		for _, c := range cerr.GetCrumbs() {
+			args = append(args, slog.Any(c.Key, c.Value))
+		}
+	}
+
+	logger.Error(msg, args...)
+}
+
+// RunExample starts a server to demonstrate the middleware
+func RunExample() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/data", Handler)
+
+	// Wrap mux with middleware
+	handler := TraceMiddleware(mux)
+
+	fmt.Println("Starting server on :8080...")
+	fmt.Println("Try: curl http://localhost:8080/api/data")
+
+	// In a real app: http.ListenAndServe(":8080", handler)
+
+	// For demonstration, let's simulate a request directly
+	req, _ := http.NewRequest("GET", "/api/data", nil)
+	w := &mockResponseWriter{}
+	handler.ServeHTTP(w, req)
+}
+
+type mockResponseWriter struct{}
+
+func (m *mockResponseWriter) Header() http.Header        { return http.Header{} }
+func (m *mockResponseWriter) Write([]byte) (int, error)  { return 0, nil }
+func (m *mockResponseWriter) WriteHeader(statusCode int) {}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sri-shubham/crumbs
 
-go 1.20
+go 1.21

--- a/integrations/slog/README.md
+++ b/integrations/slog/README.md
@@ -1,0 +1,58 @@
+# Slog Integration for Crumbs
+
+This package provides an adapter to use Go's structured logging library `log/slog` with `crumbs`. It implements the `logger.Logger` interface, allowing you to seamlessly integrate `crumbs` rich context and error handling with `slog`.
+
+## Features
+
+- **Automatic Context Extraction**: Automatically extracts crumbs from `context.Context` and adds them as structured attributes to your logs.
+- **Error Enrichment**: Automatically extracts crumbs attached to `crumbs.Error` and adds them to the log entry when logging errors.
+- **Standard Interface**: Implements the generic `logger.Logger` interface, decoupling your application code from the specific logging implementation.
+
+## Usage
+
+### Installation
+
+```bash
+go get github.com/sri-shubham/crumbs/integrations/slog
+```
+
+### Basic Usage
+
+```go
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/sri-shubham/crumbs"
+	crumbslog "github.com/sri-shubham/crumbs/integrations/slog"
+)
+
+func main() {
+	// 1. Create your slog logger
+	jsonHandler := slog.NewJSONHandler(os.Stdout, nil)
+	slogger := slog.New(jsonHandler)
+
+	// 2. Create the crumbs adapter
+	log := crumbslog.New(slogger)
+
+	// 3. Use the adapter in your application
+	ctx := context.Background()
+	
+	// Add context crumbs
+	ctx = crumbs.AddCrumb(ctx, "request_id", "req-123")
+
+	// Log info - context crumbs are automatically included
+	log.Info(ctx, "starting operation", "component", "api")
+	// Output: {"time":"...", "level":"INFO", "msg":"starting operation", "component":"api", "request_id":"req-123"}
+
+	// Create an error with crumbs
+	err := crumbs.New(ctx, "database connection failed", "db_host", "localhost")
+
+	// Log error - error crumbs AND context crumbs are included
+	log.Error(ctx, "operation failed", err)
+	// Output: {"time":"...", "level":"ERROR", "msg":"operation failed", "error":"database connection failed", "db_host":"localhost", "request_id":"req-123"}
+}
+```

--- a/integrations/slog/adapter.go
+++ b/integrations/slog/adapter.go
@@ -1,0 +1,75 @@
+package slog
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/sri-shubham/crumbs"
+	"github.com/sri-shubham/crumbs/logger"
+)
+
+// Adapter implements logger.Logger using log/slog
+type Adapter struct {
+	logger *slog.Logger
+}
+
+// New creates a new slog adapter
+func New(l *slog.Logger) *Adapter {
+	if l == nil {
+		l = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+	return &Adapter{logger: l}
+}
+
+func (l *Adapter) Debug(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelDebug, msg, nil, args...)
+}
+
+func (l *Adapter) Info(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelInfo, msg, nil, args...)
+}
+
+func (l *Adapter) Warn(ctx context.Context, msg string, args ...any) {
+	l.log(ctx, slog.LevelWarn, msg, nil, args...)
+}
+
+func (l *Adapter) Error(ctx context.Context, msg string, err error, args ...any) {
+	l.log(ctx, slog.LevelError, msg, err, args...)
+}
+
+func (l *Adapter) log(ctx context.Context, level slog.Level, msg string, err error, args ...any) {
+	if !l.logger.Enabled(ctx, level) {
+		return
+	}
+
+	// Start with provided args
+	logArgs := make([]any, 0, len(args)+4) // Pre-allocate for args + potential crumbs
+	logArgs = append(logArgs, args...)
+
+	// Add error if present
+	if err != nil {
+		logArgs = append(logArgs, "error", err.Error())
+
+		// Extract crumbs from error
+		var cerr *crumbs.Error
+		if errors.As(err, &cerr) {
+			for _, c := range cerr.GetCrumbs() {
+				logArgs = append(logArgs, c.Key, c.Value)
+			}
+		}
+	}
+
+	// Extract crumbs from context
+	if ctxCrumbs := crumbs.GetCrumbs(ctx); len(ctxCrumbs) > 0 {
+		for _, c := range ctxCrumbs {
+			logArgs = append(logArgs, c.Key, c.Value)
+		}
+	}
+
+	l.logger.Log(ctx, level, msg, logArgs...)
+}
+
+// Ensure Adapter implements logger.Logger
+var _ logger.Logger = (*Adapter)(nil)

--- a/integrations/slog/adapter_test.go
+++ b/integrations/slog/adapter_test.go
@@ -1,0 +1,82 @@
+package slog_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/sri-shubham/crumbs"
+	crumbslog "github.com/sri-shubham/crumbs/integrations/slog"
+	"github.com/sri-shubham/crumbs/logger"
+)
+
+func TestAdapter_ImplementsLogger(t *testing.T) {
+	var _ logger.Logger = (*crumbslog.Adapter)(nil)
+}
+
+func TestAdapter_Logging(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	l := slog.New(h)
+	adapter := crumbslog.New(l)
+
+	ctx := context.Background()
+
+	t.Run("Info", func(t *testing.T) {
+		buf.Reset()
+		adapter.Info(ctx, "info message", "key", "value")
+
+		var logEntry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+			t.Fatalf("failed to unmarshal log entry: %v", err)
+		}
+
+		if logEntry["msg"] != "info message" {
+			t.Errorf("expected msg 'info message', got %v", logEntry["msg"])
+		}
+		if logEntry["level"] != "INFO" {
+			t.Errorf("expected level 'INFO', got %v", logEntry["level"])
+		}
+		if logEntry["key"] != "value" {
+			t.Errorf("expected key 'value', got %v", logEntry["key"])
+		}
+	})
+
+	t.Run("Context Crumbs", func(t *testing.T) {
+		buf.Reset()
+		ctxWithCrumbs := crumbs.AddCrumb(ctx, "request_id", "12345")
+		adapter.Info(ctxWithCrumbs, "context crumbs")
+
+		var logEntry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+			t.Fatalf("failed to unmarshal log entry: %v", err)
+		}
+
+		if logEntry["request_id"] != "12345" {
+			t.Errorf("expected request_id '12345', got %v", logEntry["request_id"])
+		}
+	})
+
+	t.Run("Error Crumbs", func(t *testing.T) {
+		buf.Reset()
+		err := crumbs.New(ctx, "something went wrong", "user_id", "u-999")
+		adapter.Error(ctx, "error occurred", err)
+
+		var logEntry map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &logEntry); err != nil {
+			t.Fatalf("failed to unmarshal log entry: %v", err)
+		}
+
+		if logEntry["msg"] != "error occurred" {
+			t.Errorf("expected msg 'error occurred', got %v", logEntry["msg"])
+		}
+		if logEntry["error"] != "something went wrong" {
+			t.Errorf("expected error 'something went wrong', got %v", logEntry["error"])
+		}
+		if logEntry["user_id"] != "u-999" {
+			t.Errorf("expected user_id 'u-999', got %v", logEntry["user_id"])
+		}
+	})
+}

--- a/logger/README.md
+++ b/logger/README.md
@@ -1,0 +1,36 @@
+# Logger Interface
+
+This package defines a generic `Logger` interface for the `crumbs` ecosystem. It allows libraries and applications to log messages with context and structured data without being tied to a specific logging implementation.
+
+## Interface Definition
+
+```go
+type Logger interface {
+	Debug(ctx context.Context, msg string, args ...any)
+	Info(ctx context.Context, msg string, args ...any)
+	Warn(ctx context.Context, msg string, args ...any)
+	Error(ctx context.Context, msg string, err error, args ...any)
+}
+```
+
+## Usage
+
+Use this interface in your service or library code to accept any compatible logger.
+
+```go
+type MyService struct {
+    logger logger.Logger
+}
+
+func NewService(l logger.Logger) *MyService {
+    return &MyService{logger: l}
+}
+
+func (s *MyService) DoWork(ctx context.Context) {
+    s.logger.Info(ctx, "work started")
+}
+```
+
+## Implementations
+
+- **[slog](../integrations/slog)**: Adapter for Go's standard `log/slog` library.

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,11 @@
+package logger
+
+import "context"
+
+// Logger is a generic interface for logging with context
+type Logger interface {
+	Debug(ctx context.Context, msg string, args ...any)
+	Info(ctx context.Context, msg string, args ...any)
+	Warn(ctx context.Context, msg string, args ...any)
+	Error(ctx context.Context, msg string, err error, args ...any)
+}


### PR DESCRIPTION
## Description
This PR introduces first-class logging support to the `crumbs` ecosystem. It adds a generic `Logger` interface to decouple applications from specific logging implementations and provides a ready-to-use adapter for Go's standard `log/slog` library.

## Changes
- **New Package `logger`**: Defines a simple, generic `Logger` interface (`Debug`, `Info`, `Warn`, `Error`) that accepts `context.Context`.
- **New Package `integrations/slog`**: Implements the `Logger` interface using `log/slog`.
  - Automatically extracts crumbs from `context.Context` and adds them as log attributes.
  - Automatically extracts crumbs from `crumbs.Error` when logging errors.
- **Documentation**: Added READMEs for the new packages and updated the main README with an "Integrations" section.
- **Examples**: Added a middleware example demonstrating how to capture request-scoped metadata and propagate it to logs.

## Motivation
To make `crumbs` a complete observability solution, it needs to bridge the gap between error handling and logging. This integration ensures that the rich context collected by `crumbs` doesn't just stay in the error return path but also makes it into application logs for easier debugging.

## Testing
- Added unit tests for the `slog` adapter covering:
  - Interface compliance.
  - Log level mapping.
  - Context crumb extraction.
  - Error crumb extraction.