### PR TITLE
fix(slog): preserve crumb extraction through Adapter.With()

### DIFF
--- a/integrations/slog/adapter.go
+++ b/integrations/slog/adapter.go
@@ -13,6 +13,14 @@ import (
 // Adapter implements logger.Logger using log/slog
 type Adapter struct {
 	logger *slog.Logger
+
+	// withArgs are key-value pairs accumulated via With, merged into every
+	// subsequent log call's args (rather than baked into logger via
+	// slog.Logger.With) so they still go through the same error-stringify
+	// and crumb-splat logic as call-site args. See adapter_test.go's
+	// TestAdapter_WithPreservesErrorCrumbs for the regression this guards
+	// against.
+	withArgs []any
 }
 
 // New creates a new slog adapter
@@ -55,10 +63,17 @@ func (l *Adapter) log(ctx context.Context, level slog.Level, msg string, args ..
 		return
 	}
 
-	logArgs := make([]any, 0, len(args)+4)
+	all := args
+	if len(l.withArgs) > 0 {
+		all = make([]any, 0, len(l.withArgs)+len(args))
+		all = append(all, l.withArgs...)
+		all = append(all, args...)
+	}
+
+	logArgs := make([]any, 0, len(all)+4)
 
 	var cerr *crumbs.Error
-	for _, a := range args {
+	for _, a := range all {
 		// Replace error values with their string form so JSON/text handlers
 		// emit the message rather than an opaque struct representation. Also
 		// remember the first *crumbs.Error so we can splat its crumbs.
@@ -86,10 +101,16 @@ func (l *Adapter) log(ctx context.Context, level slog.Level, msg string, args ..
 }
 
 // With returns a derived Adapter that includes the supplied key-value args
-// on every subsequent log call. The underlying slog.Logger is preserved, so
-// crumb-extraction semantics are unchanged.
+// on every subsequent log call. Args are merged at log time (not baked into
+// the underlying slog.Logger via slog.Logger.With) so an error passed here
+// still gets stringified and, if it is a *crumbs.Error, has its crumbs
+// splatted onto every subsequent log line exactly as if passed at the call
+// site.
 func (l *Adapter) With(args ...any) logger.Logger {
-	return &Adapter{logger: l.logger.With(args...)}
+	merged := make([]any, 0, len(l.withArgs)+len(args))
+	merged = append(merged, l.withArgs...)
+	merged = append(merged, args...)
+	return &Adapter{logger: l.logger, withArgs: merged}
 }
 
 // Ensure Adapter implements logger.Logger

--- a/integrations/slog/adapter_test.go
+++ b/integrations/slog/adapter_test.go
@@ -193,3 +193,42 @@ func TestAdapter_With(t *testing.T) {
 		t.Errorf("ctx crumb missing, got %v", entry["request_id"])
 	}
 }
+
+// Regression: an error passed via With must still be stringified and have
+// its crumbs splatted on every subsequent call, same as when passed at the
+// call site. Previously With baked args straight into slog.Logger.With,
+// bypassing the adapter's error/crumb extraction entirely.
+func TestAdapter_WithPreservesErrorCrumbs(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	adapter := crumbslog.New(slog.New(h))
+	ctx := context.Background()
+
+	richErr := crumbs.New(ctx, "db failure", "table", "users", "retry", 3)
+	child := adapter.With("err", richErr)
+
+	child.Info(ctx, "first call")
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry["err"] != "db failure" {
+		t.Errorf("expected err stringified to 'db failure', got %v", entry["err"])
+	}
+	if entry["table"] != "users" {
+		t.Errorf("expected table crumb 'users', got %v", entry["table"])
+	}
+	if entry["retry"] != float64(3) {
+		t.Errorf("expected retry crumb 3, got %v", entry["retry"])
+	}
+
+	// Crumbs must reappear on a second call too, not just the first.
+	buf.Reset()
+	child.Info(ctx, "second call")
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry["table"] != "users" {
+		t.Errorf("expected table crumb on second call, got %v", entry["table"])
+	}
+}

--- a/integrations/slog/adapter_test.go
+++ b/integrations/slog/adapter_test.go
@@ -204,7 +204,7 @@ func TestAdapter_WithPreservesErrorCrumbs(t *testing.T) {
 	adapter := crumbslog.New(slog.New(h))
 	ctx := context.Background()
 
-	richErr := crumbs.New(ctx, "db failure", "table", "users", "retry", 3)
+	richErr := crumbs.NewError(ctx, "db failure", "table", "users", "retry", 3)
 	child := adapter.With("err", richErr)
 
 	child.Info(ctx, "first call")
@@ -230,5 +230,144 @@ func TestAdapter_WithPreservesErrorCrumbs(t *testing.T) {
 	}
 	if entry["table"] != "users" {
 		t.Errorf("expected table crumb on second call, got %v", entry["table"])
+	}
+}
+
+// Chained With calls must accumulate args from every link, not just the last.
+func TestAdapter_ChainedWith(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	adapter := crumbslog.New(slog.New(h))
+	ctx := context.Background()
+
+	richErr := crumbs.NewError(ctx, "db failure", "table", "users")
+	child := adapter.With("service", "checkout").With("err", richErr)
+
+	child.Info(ctx, "chained")
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry["service"] != "checkout" {
+		t.Errorf("expected service from first With, got %v", entry["service"])
+	}
+	if entry["err"] != "db failure" {
+		t.Errorf("expected err stringified from second With, got %v", entry["err"])
+	}
+	if entry["table"] != "users" {
+		t.Errorf("expected crumb from second With's error, got %v", entry["table"])
+	}
+}
+
+// A call-site arg for the same key as a With arg must override it, since
+// call-site args are appended after withArgs in the merged slice and slog's
+// JSON output keeps last-write-wins semantics for duplicate keys.
+func TestAdapter_CallSiteOverridesWith(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	adapter := crumbslog.New(slog.New(h))
+	ctx := context.Background()
+
+	child := adapter.With("stage", "auth")
+	child.Info(ctx, "ok", "stage", "checkout")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry["stage"] != "checkout" {
+		t.Errorf("expected call-site stage to win, got %v", entry["stage"])
+	}
+}
+
+// When both a With-supplied *crumbs.Error and a call-site *crumbs.Error are
+// present, the first one encountered (the With arg, since withArgs precede
+// call-site args in the merged slice) wins the crumb splat.
+func TestAdapter_WithErrorWinsOverCallSiteError(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	adapter := crumbslog.New(slog.New(h))
+	ctx := context.Background()
+
+	withErr := crumbs.NewError(ctx, "with error", "src", "with")
+	callSiteErr := crumbs.NewError(ctx, "call-site error", "src", "callsite")
+
+	child := adapter.With("err", withErr)
+	child.Error(ctx, "both", "err2", callSiteErr)
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry["src"] != "with" {
+		t.Errorf("expected With's error crumbs to win, got %v", entry["src"])
+	}
+}
+
+// A *crumbs.Error supplied via With must suppress ctx crumb lookup, same as
+// when the error is passed at the call site, to avoid duplicate crumbs.
+func TestAdapter_WithErrorSuppressesCtxCrumbs(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	adapter := crumbslog.New(slog.New(h))
+
+	withErr := crumbs.NewError(context.Background(), "boom", "src", "with")
+	child := adapter.With("err", withErr)
+
+	ctxWithCrumbs := crumbs.AddCrumb(context.Background(), "request_id", "rid-3")
+	child.Info(ctxWithCrumbs, "no dup")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := entry["request_id"]; ok {
+		t.Errorf("expected ctx crumb suppressed when With error present, got request_id=%v", entry["request_id"])
+	}
+	if entry["src"] != "with" {
+		t.Errorf("expected With error's crumb present, got %v", entry["src"])
+	}
+}
+
+// A plain (non-*crumbs.Error) error passed via With must still be
+// stringified, and since it contributes no crumbs, ctx crumbs still apply.
+func TestAdapter_WithNonCrumbsErrorStillAllowsCtxCrumbs(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	adapter := crumbslog.New(slog.New(h))
+
+	child := adapter.With("err", errors.New("boom"))
+	ctxWithCrumbs := crumbs.AddCrumb(context.Background(), "request_id", "rid-4")
+	child.Info(ctxWithCrumbs, "plain via with")
+
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry["err"] != "boom" {
+		t.Errorf("expected plain error stringified, got %v", entry["err"])
+	}
+	if entry["request_id"] != "rid-4" {
+		t.Errorf("expected ctx crumb still applied, got %v", entry["request_id"])
+	}
+}
+
+// Deriving a child via With must not mutate the parent: the parent's log
+// calls must not gain the child's withArgs.
+func TestAdapter_WithParentImmutability(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	parent := crumbslog.New(slog.New(h))
+	ctx := context.Background()
+
+	_ = parent.With("service", "checkout")
+
+	parent.Info(ctx, "parent call")
+	var entry map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := entry["service"]; ok {
+		t.Errorf("With must not mutate parent, but parent log has service=%v", entry["service"])
 	}
 }


### PR DESCRIPTION
## Summary
- `Adapter.With()` baked args straight into `slog.Logger.With`, skipping the
  adapter's error-stringify and crumb-splat logic that every other method
  (`Debug`/`Info`/`Warn`/`Error`) goes through. A `*crumbs.Error` passed via
  `With()` silently lost its crumbs on every subsequent log call.
- Fixes #10.

## Fix
`With()` now merges its args into a `withArgs` field and folds them into
`log()`'s existing arg-processing loop instead of pre-baking them into the
underlying `slog.Logger`. Same error-stringify + crumb-splat path either way.

## Test plan
- [x] Added `TestAdapter_WithPreservesErrorCrumbs` (checks crumbs survive
      across two calls after `With()`, not just the first)
- [x] `go test -race ./...` passes
- [x] `go vet ./...` clean