### PR TITLE
docs(readme): redesign homepage around the crumb-flow mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,226 +1,166 @@
-# Crumbs
+<p align="center">
+  <img src="./assets/readme/hero.svg" width="100%" alt="Crumbs — structured key-value context that travels from context.Context, through your error chain, to your logs">
+</p>
 
-[![Go Report Card](https://goreportcard.com/badge/github.com/sri-shubham/crumbs)](https://goreportcard.com/report/github.com/sri-shubham/crumbs)
-[![GoDoc](https://godoc.org/github.com/sri-shubham/crumbs?status.svg)](https://godoc.org/github.com/sri-shubham/crumbs)
-[![Coverage Status](https://coveralls.io/repos/github/sri-shubham/crumbs/badge.svg?branch=main)](https://coveralls.io/github/sri-shubham/crumbs?branch=main)
-[![GitHub Stars](https://img.shields.io/github/stars/sri-shubham/crumbs.svg)](https://github.com/sri-shubham/crumbs/stargazers)
-[![GitHub Issues](https://img.shields.io/github/issues/sri-shubham/crumbs.svg)](https://github.com/sri-shubham/crumbs/issues)
+<p align="center">
+  <a href="https://goreportcard.com/report/github.com/sri-shubham/crumbs"><img src="https://goreportcard.com/badge/github.com/sri-shubham/crumbs" alt="Go Report Card"></a>
+  <a href="https://pkg.go.dev/github.com/sri-shubham/crumbs"><img src="https://pkg.go.dev/badge/github.com/sri-shubham/crumbs.svg" alt="Go Reference"></a>
+  <a href="https://coveralls.io/github/sri-shubham/crumbs?branch=main"><img src="https://coveralls.io/repos/github/sri-shubham/crumbs/badge.svg?branch=main" alt="Coverage Status"></a>
+  <img src="https://img.shields.io/badge/go-%E2%89%A51.22-00ADD8?logo=go&logoColor=white" alt="Go 1.22+">
+  <a href="https://github.com/sri-shubham/crumbs/stargazers"><img src="https://img.shields.io/github/stars/sri-shubham/crumbs.svg" alt="GitHub Stars"></a>
+  <a href="https://github.com/sri-shubham/crumbs/issues"><img src="https://img.shields.io/github/issues/sri-shubham/crumbs.svg" alt="GitHub Issues"></a>
+</p>
 
-Crumbs is a rich observability library for Go that bridges the gap between error handling and structured logging. It allows you to attach rich, structured data ("crumbs") to your errors and context, which can then be automatically extracted by your logger or error reporter. This ensures that every error log contains the full context needed for debugging, without cluttering your function signatures.
+Crumbs attaches structured key-value data — "crumbs" — to a `context.Context`
+and to the errors you wrap. Every crumb rides along the wrap chain
+automatically, so the log line at the top of your call stack can carry the
+full story (request ID, table, user, whatever you attached) without any
+function signature threading it through by hand.
 
-## Features
+## How it flows
 
-- **Rich Observability**: Carry structured data through your call stack and attach it to errors automatically
-- **Logger Enrichment**: Feed your structured logger (like `slog`) with rich context captured deep within your application logic
-- **Context Integration**: Seamlessly propagate observability data via Go's `context.Context`
-- **Standard Library Compatible**: Works seamlessly with `errors.Is`, `errors.As`, and `errors.Unwrap`
-- **Low-Allocation Hot Paths**: Optimized for high-performance applications; common operations stay at 1–2 allocations (see benchmarks below)
+<p align="center">
+  <img src="./assets/readme/mechanism.svg" width="100%" alt="Diagram: a crumb added to context is carried into an error's snapshot alongside its own key-value pairs, then both land in the final log line with no duplicates">
+</p>
 
-## Installation
+- **Context crumbs are snapshotted once**, when an `*Error` is created —
+  not re-read as the error bubbles up, so nothing duplicates.
+- **Crumbs on the same key last-write-wins**, whether they arrive via
+  `AddCrumb`, a constructor, or `.With(...)`.
+- **Nothing is mutated in place** — `AddCrumb` returns a new `context.Context`
+  and every accessor (`GetCrumbs`) hands back a defensive copy.
+
+## Install
 
 ```bash
 go get github.com/sri-shubham/crumbs
 ```
 
-## Quick Start
+## Quick start
 
 ```go
+package main
+
 import (
-    "context"
-    "errors"
-    "fmt"
-    "github.com/sri-shubham/crumbs"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/sri-shubham/crumbs"
 )
 
 func main() {
-    ctx := context.Background()
-    
-    // Add crumbs to the context
-    ctx = crumbs.AddCrumb(ctx,
-        "requestID", "req-12345",
-        "userID", "user-abc",
-    )
-    
-    // Create a new error with additional crumbs.
-    // `New` / `Wrap` are aliases for `NewError` / `WrapError`.
-    err := crumbs.New(ctx, "operation failed",
-        "operation", "getData",
-        "status", 500,
-    )
-    
-    // Print detailed error with crumbs
-    fmt.Println(crumbs.FormatError(err, true))
-    
-    // Works with standard errors package
-    baseErr := errors.New("connection failed")
-    wrappedErr := crumbs.Wrap(ctx, baseErr, "database error")
-    
-    if errors.Is(wrappedErr, baseErr) {
-        fmt.Println("Error identity preserved!")
+	ctx := context.Background()
+	ctx = crumbs.AddCrumb(ctx, "requestID", "req-12345", "userID", "user-abc")
+
+	err := crumbs.New(ctx, "operation failed", "operation", "getData", "status", 500)
+	fmt.Println(crumbs.FormatError(err, true))
+	// operation failed
+	// Crumbs:
+	//   requestID: req-12345
+	//   userID: user-abc
+	//   operation: getData
+	//   status: 500
+
+	// Standard errors.Is / errors.As still work through the wrap chain.
+	baseErr := errors.New("connection failed")
+	wrapped := crumbs.Wrap(ctx, baseErr, "database error")
+	fmt.Println(errors.Is(wrapped, baseErr)) // true
+}
+```
+
+## Core concepts
+
+**Creating and wrapping errors** — `New`/`NewError` build a fresh `*Error`;
+`Wrap`/`WrapError` attach a message to an existing error while preserving
+`errors.Is`/`errors.As` compatibility via `Unwrap`. Both accept trailing
+key-value pairs, and `Errorf`/`Wrapf` take a format string instead:
+
+```go
+err := crumbs.New(ctx, "request failed", "status", 404, "path", "/users/123")
+err = crumbs.Wrap(ctx, baseErr, "database query failed", "query", "SELECT * FROM users")
+err = crumbs.Errorf(ctx, "failed with code %d", 500)
+```
+
+**Adding crumbs after the fact** — chain `.With(...)` on any `*Error`
+(safe for concurrent use):
+
+```go
+err := crumbs.Errorf(ctx, "code %d", 500).With("op", "x")
+```
+
+**Reading crumbs back** — `GetCrumbs` works on both a `context.Context` and
+an `*Error`; on an error it returns the full merged set (ctx crumbs +
+everything added along the wrap chain):
+
+```go
+var cerr *crumbs.Error
+if errors.As(err, &cerr) {
+    for _, c := range cerr.GetCrumbs() {
+        fmt.Printf("%s: %v\n", c.Key, c.Value)
     }
 }
 ```
 
-## Core Concepts
+**Formatting** — `FormatError(err, includeCrumbs bool)` renders the message
+chain, optionally followed by the outermost `*Error`'s crumbs.
 
-### Creating Errors
+## Logging
 
-```go
-// Create a new error
-err := crumbs.New(ctx, "something went wrong")
-
-// Create with key-value pairs
-err := crumbs.New(ctx, "request failed", 
-    "status", 404,
-    "path", "/users/123",
-)
-
-// Create with formatting
-err := crumbs.Errorf(ctx, "failed with code %d", 500)
-```
-
-### Wrapping Errors
-
-```go
-// Wrap an existing error
-baseErr := errors.New("network timeout")
-err := crumbs.Wrap(ctx, baseErr, "API request failed")
-
-// Wrap with key-value pairs
-err := crumbs.Wrap(ctx, baseErr, "database query failed",
-    "query", "SELECT * FROM users",
-    "params", []string{"id=123"},
-)
-
-// Wrap with formatting
-err := crumbs.Wrapf(ctx, baseErr, "operation %s failed", "getData")
-```
-
-### Working with Context
-
-```go
-// Add crumbs to context
-ctx = crumbs.AddCrumb(ctx, "userID", "user-123")
-
-// Add multiple crumbs
-ctx = crumbs.AddCrumb(ctx, 
-    "requestID", "req-abc",
-    "traceID", "trace-xyz",
-    "timestamp", time.Now(),
-)
-
-// Get crumbs from context (returns []Crumb)
-allCrumbs := crumbs.GetCrumbs(ctx)
-for _, c := range allCrumbs {
-    fmt.Printf("Key: %s, Value: %v\n", c.Key, c.Value)
-}
-```
-
-### Error Formatting
-
-```go
-// Format error with crumbs
-formatted := crumbs.FormatError(err, true)
-
-// Format without crumbs (just the message chain)
-formatted := crumbs.FormatError(err, false)
-```
-
-### Extracting Data
-
-With `crumbs`, context is seamlessly merged all the way up the error chain. When you call `GetCrumbs()` on an error wrapper, it organically provides all key-value pairs collected at every level!
-
-```go
-if cerr, ok := err.(*crumbs.Error); ok {
-    // Get all nested crumbs from the entire error chain
-    allCrumbs := cerr.GetCrumbs()
-    for _, c := range allCrumbs {
-        fmt.Printf("Key: %s, Value: %v\n", c.Key, c.Value)
-    }
-}
-```
-
-## Logging Integration
-
-Crumbs integrates seamlessly with modern structured logging like `log/slog`.
-For the quickest path, use the first-class adapter at
-[`integrations/slog`](./integrations/slog) which extracts crumbs automatically
-from both context and errors:
+The first-class [`integrations/slog`](./integrations/slog) adapter extracts
+crumbs from context and from any `*crumbs.Error` in the log args
+automatically — no manual plumbing:
 
 ```go
 import crumbslog "github.com/sri-shubham/crumbs/integrations/slog"
 
 log := crumbslog.New(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
-log.Error(ctx, "operation failed", "error", err) // crumbs splatted automatically
+log.Error(ctx, "operation failed", "err", err) // crumbs splatted automatically
 ```
 
-If you prefer to wire `slog` yourself, the patterns below show manual
-extraction:
+`With(args...)` on the adapter works the same way: anything you pin there
+still gets stringified and crumb-extracted on every subsequent call.
+
+<details>
+<summary>Wiring <code>log/slog</code> yourself, without the adapter</summary>
 
 ```go
-import "log/slog"
-
-// LogError logs an error along with all its attached crumbs
 func LogError(logger *slog.Logger, msg string, err error) {
-    // Start with the error itself
-    args := []any{"error", err}
+	args := []any{"error", err}
 
-    // Extract crumbs if available
-    var cerr *crumbs.Error
-    if errors.As(err, &cerr) {
-        for _, c := range cerr.GetCrumbs() {
-            // Add each crumb as a key-value pair
-            args = append(args, slog.Any(c.Key, c.Value))
-        }
-    }
+	var cerr *crumbs.Error
+	if errors.As(err, &cerr) {
+		for _, c := range cerr.GetCrumbs() {
+			args = append(args, slog.Any(c.Key, c.Value))
+		}
+	}
 
-    // Log with all context
-    logger.Error(msg, args...)
-}
-
-// LoggerWithCrumbs creates a logger pre-filled with error context
-func LoggerWithCrumbs(logger *slog.Logger, err error) *slog.Logger {
-    var cerr *crumbs.Error
-    if errors.As(err, &cerr) {
-        crumbs := cerr.GetCrumbs()
-        args := make([]any, 0, len(crumbs)*2)
-        for _, c := range crumbs {
-            args = append(args, c.Key, c.Value)
-        }
-        return logger.With(args...)
-    }
-    return logger
+	logger.Error(msg, args...)
 }
 ```
 
-## Examples
-
-See the [examples](./examples) directory for comprehensive usage examples:
-
-- Basic usage patterns
-- Context integration
-- Logging integration
-- Standard library errors compatibility
-- HTTP middleware
+</details>
 
 ## Integrations
 
-Crumbs is designed to play nicely with the Go ecosystem.
+- **[slog adapter](./integrations/slog)** — `logger.Logger` implementation on
+  top of `log/slog`.
+- **[logger interface](./logger)** — the generic interface to target if you
+  want to build an adapter for another logging backend.
+- **[Middleware example](./examples/middleware_example)** — capture
+  request-scoped metadata (request ID, user ID, path) at the edge and
+  propagate it through `context.Context`.
 
-### Logging
+## Examples
 
-We provide a first-class integration for `log/slog` via the `integrations/slog` package. This adapter automatically extracts crumbs from your context and errors, injecting them as structured attributes into your logs.
-
-- **[slog Adapter](./integrations/slog)**: Seamless integration with Go's structured logger.
-- **[Logger Interface](./logger)**: A generic interface for building your own logging adapters.
-
-### Middleware
-
-Crumbs works great with HTTP middleware to capture request-scoped metadata (like Request ID, User ID, Path) at the edge and propagate it automatically through your application. See the [Middleware Example](./examples/middleware_example) for a demonstration.
+The [examples](./examples) directory has runnable code for basic usage,
+context propagation, logging integration, standard-library `errors`
+compatibility, and HTTP middleware.
 
 ## Benchmarks
 
-Performance is a key consideration in error handling. Below are benchmark results comparing standard errors with Crumbs:
+Common operations stay at 1–2 allocations. Measured on Apple M1
+(`go test -bench=. -benchmem`):
 
 ```
 goos: darwin
@@ -239,12 +179,14 @@ BenchmarkGetCrumbs-8                         43355341                27.47 ns/op
 BenchmarkFormatError-8                        4431264               271.9 ns/op           184 B/op           8 allocs/op
 ```
 
-For more detailed benchmark information and analysis, see [BENCHMARKS.md](./BENCHMARKS.md).
+See [BENCHMARKS.md](./BENCHMARKS.md) for what each benchmark measures and
+[CHANGELOG.md](./CHANGELOG.md) for release history.
 
 ## Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for details on how to contribute to this project.
+Contributions are welcome — see [CONTRIBUTING.md](./CONTRIBUTING.md) for bug
+report, pull request, and style guidelines.
 
 ## License
 
-[MIT License](./LICENSE) - Copyright (c) 2025 Shubham Srivastava
+[MIT License](./LICENSE) — Copyright (c) 2025 Shubham Srivastava

--- a/assets/readme/hero.svg
+++ b/assets/readme/hero.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="420" viewBox="0 0 1200 420"
+     role="img" aria-labelledby="hero-title hero-desc">
+  <title id="hero-title">Crumbs — structured context for Go errors</title>
+  <desc id="hero-desc">A crumb dropped into context.Background(), carried through AddCrumb and Wrap, and landing intact in a structured log line.</desc>
+
+  <defs>
+    <style>
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="420" rx="26" fill="#0B0D10"/>
+  <rect x="1" y="1" width="1198" height="418" rx="25" fill="none" stroke="#1B1F24" stroke-width="1.5"/>
+
+  <!-- divider -->
+  <line x1="632" y1="56" x2="632" y2="380" stroke="#7C8792" stroke-opacity="0.25" stroke-width="1.5"/>
+
+  <!-- title block -->
+  <g class="sans">
+    <text x="64" y="60" class="mono" font-size="15" letter-spacing="2" fill="#7C8792">GO LIBRARY&#160;&#160;&#183;&#160;&#160;STRUCTURED ERROR CONTEXT</text>
+
+    <circle cx="72" cy="122" r="7" fill="#E2A34E"/>
+    <circle cx="72" cy="122" r="12" fill="none" stroke="#E2A34E" stroke-opacity="0.4" stroke-width="1.5"/>
+    <text x="96" y="138" font-size="80" font-weight="700" fill="#F3EFE8">Crumbs</text>
+
+    <text x="65" y="196" font-size="21" fill="#F3EFE8" fill-opacity="0.88">Structured key-value context that travels</text>
+    <text x="65" y="226" font-size="21" fill="#F3EFE8" fill-opacity="0.88">from <tspan class="mono" fill="#E2A34E">ctx</tspan>, through your error chain, to your logs.</text>
+
+    <rect x="64" y="326" width="460" height="44" rx="22" fill="#14181D" stroke="#7C8792" stroke-opacity="0.3"/>
+    <text x="84" y="354" class="mono" font-size="16" fill="#F3EFE8">$ go get github.com/sri-shubham/crumbs</text>
+  </g>
+
+  <!-- mechanism preview -->
+  <g class="mono">
+    <line x1="700" y1="60" x2="700" y2="300" stroke="#7C8792" stroke-opacity="0.35" stroke-width="1.5" stroke-dasharray="2 7"/>
+
+    <circle cx="700" cy="70" r="6" fill="#E2A34E"/>
+    <text x="726" y="75" font-size="16" fill="#F3EFE8" fill-opacity="0.9">ctx := context.Background()</text>
+
+    <circle cx="700" cy="150" r="6" fill="#E2A34E"/>
+    <circle cx="700" cy="150" r="10" fill="none" stroke="#E2A34E" stroke-opacity="0.4" stroke-width="1.5"/>
+    <text x="726" y="145" font-size="16" fill="#F3EFE8">AddCrumb(ctx,</text>
+    <text x="726" y="167" font-size="16" fill="#F3EFE8">&#160;&#160;"user_id", "u-42")</text>
+
+    <circle cx="700" cy="230" r="6" fill="#E2A34E"/>
+    <circle cx="700" cy="230" r="10" fill="none" stroke="#E2A34E" stroke-opacity="0.4" stroke-width="1.5"/>
+    <text x="726" y="225" font-size="16" fill="#F3EFE8">Wrap(ctx, err,</text>
+    <text x="726" y="247" font-size="16" fill="#F3EFE8">&#160;&#160;"db failure")</text>
+
+    <path d="M700 300 L700 312" stroke="#7C8792" stroke-opacity="0.35" stroke-width="1.5"/>
+    <path d="M694 306 L700 314 L706 306" fill="none" stroke="#7C8792" stroke-opacity="0.6" stroke-width="1.5"/>
+
+    <rect x="680" y="312" width="460" height="60" rx="14" fill="#14181D" stroke="#7C8792" stroke-opacity="0.3"/>
+    <circle cx="698" cy="328" r="3" fill="#7C8792" fill-opacity="0.6"/>
+    <circle cx="710" cy="328" r="3" fill="#7C8792" fill-opacity="0.6"/>
+    <circle cx="722" cy="328" r="3" fill="#7C8792" fill-opacity="0.6"/>
+    <text x="738" y="331" font-size="12" fill="#7C8792">log.Error output</text>
+    <text x="698" y="356" font-size="15" fill="#F3EFE8">{"err":"db failure","user_id":"u-42"}</text>
+  </g>
+</svg>

--- a/assets/readme/mechanism.svg
+++ b/assets/readme/mechanism.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     width="1200" height="440" viewBox="0 0 1200 440"
+     role="img" aria-labelledby="mech-title mech-desc">
+  <title id="mech-title">How crumbs flow: context, error, log line</title>
+  <desc id="mech-desc">A crumb added to context is carried into an error's snapshot alongside its own key-value pairs, then both land in the final log line with no duplicates.</desc>
+
+  <defs>
+    <style>
+      .sans { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", sans-serif; }
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    </style>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0 0 L10 5 L0 10 z" fill="#7C8792" fill-opacity="0.7"/>
+    </marker>
+  </defs>
+
+  <rect width="1200" height="440" rx="26" fill="#0B0D10"/>
+  <rect x="1" y="1" width="1198" height="438" rx="25" fill="none" stroke="#1B1F24" stroke-width="1.5"/>
+
+  <text x="68" y="56" class="sans" font-size="30" font-weight="700" fill="#F3EFE8">How crumbs flow</text>
+  <text x="68" y="82" class="mono" font-size="14" fill="#7C8792">context.Context&#160;&#8594;&#160;*crumbs.Error&#160;&#8594;&#160;log line</text>
+
+  <!-- connectors -->
+  <line x1="398" y1="250" x2="435" y2="250" stroke="#7C8792" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <line x1="765" y1="250" x2="802" y2="250" stroke="#7C8792" stroke-width="1.5" marker-end="url(#arrow)"/>
+
+  <!-- card 1: context -->
+  <g>
+    <rect x="68" y="110" width="330" height="300" rx="18" fill="#14181D" stroke="#7C8792" stroke-opacity="0.3"/>
+    <text x="92" y="146" class="mono" font-size="13" letter-spacing="1.5" fill="#7C8792">1&#160;&#183;&#160;CONTEXT</text>
+
+    <text x="92" y="184" class="mono" font-size="15" fill="#F3EFE8">ctx := context.Background()</text>
+    <text x="92" y="210" class="mono" font-size="15" fill="#F3EFE8">ctx = AddCrumb(ctx,</text>
+    <text x="92" y="234" class="mono" font-size="15" fill="#F3EFE8">&#160;&#160;"request_id", "rid-1")</text>
+
+    <rect x="92" y="278" width="150" height="34" rx="17" fill="#0B0D10" stroke="#E2A34E" stroke-opacity="0.5"/>
+    <circle cx="110" cy="295" r="5" fill="#E2A34E"/>
+    <text x="124" y="300" class="mono" font-size="14" fill="#F3EFE8">request_id</text>
+
+    <text x="92" y="344" class="sans" font-size="14" fill="#7C8792">Held on ctx. Nothing is</text>
+    <text x="92" y="364" class="sans" font-size="14" fill="#7C8792">wrapped or logged yet.</text>
+  </g>
+
+  <!-- card 2: error -->
+  <g>
+    <rect x="435" y="110" width="330" height="300" rx="18" fill="#14181D" stroke="#7C8792" stroke-opacity="0.3"/>
+    <text x="459" y="146" class="mono" font-size="13" letter-spacing="1.5" fill="#7C8792">2&#160;&#183;&#160;ERROR</text>
+
+    <text x="459" y="184" class="mono" font-size="15" fill="#F3EFE8">err := crumbs.Wrap(ctx,</text>
+    <text x="459" y="208" class="mono" font-size="15" fill="#F3EFE8">&#160;&#160;dbErr, "query failed",</text>
+    <text x="459" y="232" class="mono" font-size="15" fill="#F3EFE8">&#160;&#160;"table", "users")</text>
+
+    <rect x="459" y="278" width="140" height="34" rx="17" fill="#0B0D10" stroke="#E2A34E" stroke-opacity="0.5"/>
+    <circle cx="477" cy="295" r="5" fill="#E2A34E"/>
+    <text x="491" y="300" class="mono" font-size="14" fill="#F3EFE8">request_id</text>
+    <rect x="609" y="278" width="100" height="34" rx="17" fill="#0B0D10" stroke="#E2A34E" stroke-opacity="0.5"/>
+    <circle cx="627" cy="295" r="5" fill="#E2A34E"/>
+    <text x="641" y="300" class="mono" font-size="14" fill="#F3EFE8">table</text>
+
+    <text x="459" y="344" class="sans" font-size="14" fill="#7C8792">Snapshots ctx crumbs once,</text>
+    <text x="459" y="364" class="sans" font-size="14" fill="#7C8792">then adds its own kv pairs.</text>
+  </g>
+
+  <!-- card 3: log line -->
+  <g>
+    <rect x="802" y="110" width="330" height="300" rx="18" fill="#14181D" stroke="#7C8792" stroke-opacity="0.3"/>
+    <text x="826" y="146" class="mono" font-size="13" letter-spacing="1.5" fill="#7C8792">3&#160;&#183;&#160;LOG LINE</text>
+
+    <text x="826" y="184" class="mono" font-size="15" fill="#F3EFE8">log.Error(ctx, "failed",</text>
+    <text x="826" y="208" class="mono" font-size="15" fill="#F3EFE8">&#160;&#160;"err", err)</text>
+
+    <rect x="826" y="234" width="282" height="92" rx="12" fill="#0B0D10" stroke="#7C8792" stroke-opacity="0.3"/>
+    <circle cx="844" cy="250" r="3" fill="#7C8792" fill-opacity="0.6"/>
+    <circle cx="856" cy="250" r="3" fill="#7C8792" fill-opacity="0.6"/>
+    <circle cx="868" cy="250" r="3" fill="#7C8792" fill-opacity="0.6"/>
+    <text x="884" y="253" class="mono" font-size="12" fill="#7C8792">structured attrs</text>
+    <text x="844" y="276" class="mono" font-size="14" fill="#F3EFE8">request_id: "rid-1"</text>
+    <text x="844" y="298" class="mono" font-size="14" fill="#F3EFE8">table:&#160;&#160;&#160;&#160;&#160;&#160;"users"</text>
+    <text x="826" y="360" class="sans" font-size="14" fill="#7C8792">Both crumbs, no duplicates,</text>
+    <text x="826" y="380" class="sans" font-size="14" fill="#7C8792">no manual plumbing.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- Adds `assets/readme/hero.svg` and `assets/readme/mechanism.svg` — a
  project-native visual (context -> error -> log line, crumb-dot motif)
  instead of plain text badges.
- Reorders README: value -> mechanism diagram -> install -> quick start
  (output verified by running it) -> condensed core concepts -> logging
  (adapter-first, manual slog wiring moved into a `<details>`) ->
  integrations -> examples -> benchmarks (unchanged real numbers) ->
  contributing -> license.
- Swaps the dead `godoc.org` badge for `pkg.go.dev`, adds a Go-version badge,
  links the existing `CHANGELOG.md` (wasn't referenced anywhere before).
- No behavior/API changes -- docs and static assets only.

## Test plan
- [x] Verified the Quick Start snippet's claimed output by actually running it
- [x] Rendered both SVGs and checked legibility at GitHub content width